### PR TITLE
Feature/open api - include OpenAPI and mock data for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,6 @@ The application includes mock data for testing purposes. When the application st
 
 You can view and interact with this mock data through the API endpoints or the Swagger UI interface.
 
-## Authentication
-
-The API uses JWT for authentication. To authenticate:
-
-1. Use the `/api/v1/auth/login` endpoint with valid credentials
-2. Include the returned JWT token in the Authorization header for subsequent requests:
-   ```
-   Authorization: Bearer <your_token>
-   ```
-
 ### Swagger UI Authentication
 
 To test secured endpoints in Swagger UI:
@@ -79,15 +69,6 @@ To test secured endpoints in Swagger UI:
 
 5. Click "Authorize" and close the popup. All subsequent API requests will include your token.
 
-#### Sample Token for Testing
-
-For quick testing, you can use this pre-generated token (valid for admin@example.com):
-```
-Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbkBleGFtcGxlLmNvbSIsImF1dGgiOiJBRE1JTiIsImlhdCI6MTcxODU5ODQwMCwiZXhwIjoxNzE5NDYyNDAwfQ.DjkXg4QYgST4Qe0IV9L0i4fx5-kBzQXJwR9IOYPfLqc
-```
-
-Note: This token is for testing purposes only and will expire on June 26, 2025. For production use, always generate a fresh token using the login endpoint.
-
 ## Main Endpoints
 
 - `/api/v1/users` - User management
@@ -96,12 +77,3 @@ Note: This token is for testing purposes only and will expire on June 26, 2025. 
 - `/api/v1/auth` - Authentication and registration
 
 For detailed information about each endpoint, refer to the Swagger UI documentation.
-
-## Java 23 Compatibility Notes
-
-This project uses Java 23, which may display certain JVM warnings. The following JVM arguments have been configured in the Maven plugins to address these warnings:
-
-- `-XX:+EnableDynamicAgentLoading`: Suppresses warnings about dynamic agent loading, which can occur with certain testing frameworks.
-- `-Xshare:off`: Disables Class Data Sharing (CDS) to prevent warnings about "Sharing is only supported for boot loader classes".
-
-These arguments are configured in both the Maven Surefire plugin (for tests) and the Spring Boot Maven plugin (for running the application).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,107 @@
-# tournaments-backend
+# Tournaments Backend
+
+This is a Spring Boot application that provides a RESTful API for managing tournaments, teams, leagues, and users.
+
+## Getting Started
+
+### Prerequisites
+
+- Java 23
+- Maven
+- PostgreSQL
+
+### Installation
+
+1. Clone the repository
+2. Configure your PostgreSQL database in `application.properties`
+3. Run the application using Maven:
+
+```bash
+./mvnw spring-boot:run
+```
+
+## API Documentation
+
+The API documentation is available through OpenAPI (Swagger UI). You can access it at:
+
+```
+http://localhost:8080/swagger-ui.html
+```
+
+The OpenAPI JSON specification is available at:
+
+```
+http://localhost:8080/v3/api-docs
+```
+
+## Mock Data
+
+The application includes mock data for testing purposes. When the application starts with `spring.jpa.hibernate.ddl-auto=create-drop` (default in development), the following mock data is automatically loaded:
+
+### Users
+- Admin user: admin@example.com / password
+- Regular user: user@example.com / password
+
+### Teams
+- Several sample teams are created with random players
+
+### Leagues
+- Sample leagues with teams assigned to them
+
+You can view and interact with this mock data through the API endpoints or the Swagger UI interface.
+
+## Authentication
+
+The API uses JWT for authentication. To authenticate:
+
+1. Use the `/api/v1/auth/login` endpoint with valid credentials
+2. Include the returned JWT token in the Authorization header for subsequent requests:
+   ```
+   Authorization: Bearer <your_token>
+   ```
+
+### Swagger UI Authentication
+
+To test secured endpoints in Swagger UI:
+
+1. First, obtain a JWT token by using the `/api/v1/auth/login` endpoint with one of the mock users:
+   - Admin user: `admin@example.com` / `password`
+   - Regular user: `user@example.com` / `password`
+
+2. The token will be returned in the Authorization header of the response.
+
+3. In the Swagger UI interface, click the "Authorize" button (lock icon) at the top right.
+
+4. In the authorization popup, enter your token in the format:
+   ```
+   Bearer <your_token>
+   ```
+
+5. Click "Authorize" and close the popup. All subsequent API requests will include your token.
+
+#### Sample Token for Testing
+
+For quick testing, you can use this pre-generated token (valid for admin@example.com):
+```
+Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbkBleGFtcGxlLmNvbSIsImF1dGgiOiJBRE1JTiIsImlhdCI6MTcxODU5ODQwMCwiZXhwIjoxNzE5NDYyNDAwfQ.DjkXg4QYgST4Qe0IV9L0i4fx5-kBzQXJwR9IOYPfLqc
+```
+
+Note: This token is for testing purposes only and will expire on June 26, 2025. For production use, always generate a fresh token using the login endpoint.
+
+## Main Endpoints
+
+- `/api/v1/users` - User management
+- `/api/v1/teams` - Team management
+- `/api/v1/leagues` - League management
+- `/api/v1/auth` - Authentication and registration
+
+For detailed information about each endpoint, refer to the Swagger UI documentation.
+
+## Java 23 Compatibility Notes
+
+This project uses Java 23, which may display certain JVM warnings. The following JVM arguments have been configured in the Maven plugins to address these warnings:
+
+- `-XX:+EnableDynamicAgentLoading`: Suppresses warnings about dynamic agent loading, which can occur with certain testing frameworks.
+- `-Xshare:off`: Disables Class Data Sharing (CDS) to prevent warnings about "Sharing is only supported for boot loader classes".
+
+These arguments are configured in both the Maven Surefire plugin (for tests) and the Spring Boot Maven plugin (for running the application).

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.2</version>
+		<version>3.2.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -37,7 +37,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
-			<version>3.4.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -46,12 +45,11 @@
 		<dependency>
     		<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
-			<version>3.4.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
-			<version>6.4.3</version>
+			<version>6.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -73,7 +71,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
-			<version>3.4.2</version>
 		</dependency>
 		 <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -91,6 +88,11 @@
 			<version>0.12.6</version>
 			<scope>runtime</scope>
 		</dependency>
+	<dependency>
+		<groupId>org.springdoc</groupId>
+		<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+		<version>2.2.0</version>
+	</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,16 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<jvmArguments>-XX:+EnableDynamicAgentLoading -Xshare:off</jvmArguments>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>-XX:+EnableDynamicAgentLoading -Xshare:off</argLine>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/example/tournaments_backend/app_user/AppUserConfig.java
+++ b/src/main/java/com/example/tournaments_backend/app_user/AppUserConfig.java
@@ -1,28 +1,70 @@
 package com.example.tournaments_backend.app_user;
 
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import com.example.tournaments_backend.league.League;
+import com.example.tournaments_backend.league.LeagueRepository;
+import com.example.tournaments_backend.team.Team;
+import com.example.tournaments_backend.team.TeamRepository;
 
 @Configuration
 public class AppUserConfig {
-    
-    @Bean
-    CommandLineRunner commandLineRunner(AppUserRepository appUserRepository) {
-        return args -> {
-            // Person heri = new Person(
-            // "Heriberto",
-            // "Rodriguez",
-            // "hrodriguez@gmail.com",
-            // "djiaogdb");
-            
-            // Person bray = new Person(
-            // "Brayan",
-            // "Rodriguez",
-            // "brodriguez@gmail.com",
-            // "idjgioadjo");
 
-            // personRepository.saveAll(List.of(heri, bray));
+    @Bean
+    CommandLineRunner commandLineRunner(
+            AppUserRepository appUserRepository, 
+            LeagueRepository leagueRepository,
+            TeamRepository teamRepository,
+            BCryptPasswordEncoder passwordEncoder) {
+        return args -> {
+            // Create and save users
+            AppUser user = new AppUser(
+                "User",
+                "Example",
+                "user@example.com",
+                passwordEncoder.encode("password"),
+                AppUserRole.USER
+            );
+            user.setEnabled(true); // Enable the user so they can log in
+
+            AppUser admin = new AppUser(
+                "Admin",
+                "User",
+                "admin@example.com",
+                passwordEncoder.encode("admin123"),
+                AppUserRole.ADMIN
+            );
+            admin.setEnabled(true);
+
+            appUserRepository.saveAll(Arrays.asList(user, admin));
+
+            // Create and save teams
+            Team team1 = new Team("Barcelona FC");
+            Team team2 = new Team("Real Madrid");
+            Team team3 = new Team("Manchester United");
+            Team team4 = new Team("Liverpool");
+
+            teamRepository.saveAll(Arrays.asList(team1, team2, team3, team4));
+
+            // Create and save leagues
+            League league1 = new League("La Liga", LocalDate.now().plusDays(7), 12);
+            league1.addTeam(team1);
+            league1.addTeam(team2);
+
+            League league2 = new League("Premier League", LocalDate.now().plusDays(14), 10);
+            league2.addTeam(team3);
+            league2.addTeam(team4);
+
+            leagueRepository.saveAll(Arrays.asList(league1, league2));
+
+            System.out.println("Database initialized with mock data!");
         };
     }
 }

--- a/src/main/java/com/example/tournaments_backend/app_user/AppUserController.java
+++ b/src/main/java/com/example/tournaments_backend/app_user/AppUserController.java
@@ -16,8 +16,16 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 @RestController
 @RequestMapping(path="/api/v1/users")
+@Tag(name = "User Management", description = "API endpoints for managing users")
 public class AppUserController {
     private final AppUserService appUserService;
 
@@ -26,6 +34,12 @@ public class AppUserController {
         this.appUserService = appUserService;
     }
 
+    @Operation(summary = "Get current user information", description = "Returns the details of the currently authenticated user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved user information", 
+                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserDTO.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - not authenticated")
+    })
     @GetMapping("/me")
     public ResponseEntity<?> getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -41,21 +55,46 @@ public class AppUserController {
         return ResponseEntity.ok(resBody);
     }
 
+    @Operation(summary = "Get all users", description = "Returns a list of all users in the system")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved list of users", 
+                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = AppUser.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - not authenticated")
+    })
     @GetMapping
     public List<AppUser> getPersons() {
         return appUserService.getAppUsers();
     }
 
+    @Operation(summary = "Add a new user", description = "Creates a new user in the system")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "User successfully created"),
+        @ApiResponse(responseCode = "400", description = "Invalid input data"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - not authenticated")
+    })
     @PostMapping
     public void addUser(@RequestBody AppUser user) {
         appUserService.addUser(user);
     }
 
+    @Operation(summary = "Delete a user", description = "Deletes a user from the system by ID")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "User successfully deleted"),
+        @ApiResponse(responseCode = "404", description = "User not found"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - not authenticated")
+    })
     @DeleteMapping(path = "{userId}")
     public void deleteUser(@PathVariable("userId") Long userId) {
         appUserService.deleteUser(userId);
     }
 
+    @Operation(summary = "Update a user", description = "Updates an existing user's information")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "User successfully updated"),
+        @ApiResponse(responseCode = "400", description = "Invalid input data"),
+        @ApiResponse(responseCode = "404", description = "User not found"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - not authenticated")
+    })
     @PutMapping("{userId}")
     public void updateUser(@PathVariable("userId") Long userId, @RequestBody AppUser updatedAppUser) {
         appUserService.updateUser(userId, updatedAppUser);

--- a/src/main/java/com/example/tournaments_backend/config/OpenApiConfig.java
+++ b/src/main/java/com/example/tournaments_backend/config/OpenApiConfig.java
@@ -1,0 +1,53 @@
+package com.example.tournaments_backend.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI myOpenAPI() {
+        Server devServer = new Server();
+        // Could be improved by moving this to env variables.
+        devServer.setUrl("http://localhost:8080");
+        devServer.setDescription("Server URL in Development environment");
+
+        Info info = new Info()
+                .title("Tournaments API")
+                .version("0.1")
+                .description("This API exposes endpoints to manage tournaments, teams, leagues, and users.");
+
+        // JWT security scheme definiton
+        SecurityScheme jwtScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        // Security scheme to the components
+        Components components = new Components()
+                .addSecuritySchemes("bearerAuth", jwtScheme);
+
+        // Security requirement for all endpoints (except those explicitly permitted in SecurityConfig)
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("bearerAuth");
+
+        return new OpenAPI()
+                .info(info)
+                .servers(List.of(devServer))
+                .components(components)
+                .addSecurityItem(securityRequirement);
+    }
+}

--- a/src/main/java/com/example/tournaments_backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/tournaments_backend/security/config/SecurityConfig.java
@@ -38,7 +38,11 @@ public class SecurityConfig {
 
         http
             .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/api/v*/auth/**")
+                .requestMatchers("/api/v*/auth/**", 
+                                 "/swagger-ui.html", 
+                                 "/swagger-ui/**", 
+                                 "/v3/api-docs", 
+                                 "/v3/api-docs/**")
                 .permitAll()
                 .anyRequest()
                 .authenticated()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,10 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.connectiontimeout=5000
 spring.mail.properties.mail.smtp.timeout=3000
 spring.mail.properties.mail.smtp.writetimeout=5000
+
+# OpenAPI Configuration
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.tagsSorter=alpha
+springdoc.swagger-ui.tryItOutEnabled=true


### PR DESCRIPTION
This PR introduces two important improvements to our development workflow:

**OpenAPI docs**

You can quickly see all the available endpoints and their schemas.
So Tools like Swagger UI or Postman will just work out of the box.
It’ll be easier for anyone (including frontend) to explore and test the API without digging into the code.

Mock data for dev
I also added some basic mock data to the database when running in the dev profile — things like users, leagues, and teams. This makes it easier to:

Test features locally without having to create everything manually.
Share consistent data with others when debugging or pairing.

Additional information and usage can be found in the README file.

![image](https://github.com/user-attachments/assets/8b1ccc50-72c6-48c2-9562-9b66d2eed69d)

![image](https://github.com/user-attachments/assets/1c3f23e4-c127-47b0-9e06-1c0102dc146d)

