### PR TITLE
feat(devx): add organized local Docker Compose setup for PostgreSQL + MailDev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# --- Database Configuration ---
+POSTGRES_DB=tournaments
+POSTGRES_USER=your_username_here
+POSTGRES_PASSWORD=your_password_here
+
+# --- Spring Boot Configuration ---
+# The hostname should match the service name in compose.yaml (e.g., 'postgres')
+SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/tournaments
+SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}
+SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+
+# --- MailDev Configuration ---
+# Default ports for MailDev are usually 1025 (SMTP) and 1080 (Web UI)
+MAILDEV_SMTP_PORT=1025
+MAILDEV_UI_PORT=1080

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,10 @@ build/
 .vscode/
 
 src/main/resources/app.key
+
+# Ignore all environment files
+.env
+.env.*
+
+# But do NOT ignore the example file so others know what variables to use
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM eclipse-temurin:25.0.2_10-jdk-jammy AS builder
+WORKDIR /opt/app
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
+RUN ./mvnw dependency:go-offline
+COPY ./src ./src
+RUN ./mvnw clean install -DskipTests
+
+FROM eclipse-temurin:25.0.2_10-jre-jammy AS final
+WORKDIR /opt/app
+EXPOSE 8080
+COPY --from=builder /opt/app/target/*.jar /opt/app/*.jar
+ENTRYPOINT ["java", "-jar", "/opt/app/*.jar"]

--- a/README.md
+++ b/README.md
@@ -8,13 +8,31 @@ This is a Spring Boot application that provides a RESTful API for managing tourn
 
 - Java 23
 - Maven
-- PostgreSQL
+- Docker (recommended)
+
+### Local dependencies (recommended)
+
+The backend depends on **PostgreSQL** and **MailDev** for local development.
+
+For setup and usage instructions, see:
+
+- [`devops/local/README.md`](devops/local/README.md)
 
 ### Installation
 
 1. Clone the repository
-2. Configure your PostgreSQL database in `application.properties`
+2. Start local dependencies by following:
+   - [`devops/local/README.md`](devops/local/README.md)
+
 3. Run the application using Maven:
+
+```bash
+./mvnw spring-boot:run
+```
+
+### Alternative (without Docker)
+
+Install PostgreSQL and MailDev locally, configure values in `application.properties`, and run:
 
 ```bash
 ./mvnw spring-boot:run

--- a/devops/local/README.md
+++ b/devops/local/README.md
@@ -1,0 +1,80 @@
+# Local development dependencies
+
+This folder contains local infrastructure for backend development.
+
+## Requirements
+
+- **Docker is required** (Docker Engine + Docker Compose plugin).
+
+You can verify your installation with:
+
+```bash
+docker --version
+docker compose version
+```
+
+## Install Docker
+
+### Ubuntu / Debian (recommended)
+
+Use Docker's official installation guide:
+
+- [Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/)
+
+After installation, allow running Docker without `sudo` (recommended):
+
+```bash
+sudo usermod -aG docker "$USER"
+newgrp docker
+```
+
+### macOS
+
+Install **Docker Desktop**:
+
+- [Docker Desktop for Mac](https://docs.docker.com/desktop/setup/install/mac-install/)
+
+### Windows
+
+Install **Docker Desktop**:
+
+- [Docker Desktop for Windows](https://docs.docker.com/desktop/setup/install/windows-install/)
+
+> Note: On Windows, enable WSL2 integration for best compatibility.
+
+## Services
+
+- **PostgreSQL** on `localhost:5432`
+- **MailDev SMTP** on `localhost:1025`
+- **MailDev UI** on `http://localhost:1080`
+
+## Start services
+
+```bash
+docker compose -f devops/local/docker-compose.yml up -d
+```
+
+## Stop services
+
+```bash
+docker compose -f devops/local/docker-compose.yml down
+```
+
+## View logs
+
+```bash
+docker compose -f devops/local/docker-compose.yml logs -f
+```
+
+## Run backend app
+
+After dependencies are up:
+
+```bash
+./mvnw spring-boot:run
+```
+
+## Notes
+
+- Database config is aligned with `src/main/resources/application.properties`.
+- If ports are occupied, stop conflicting services or adjust port mappings.

--- a/devops/local/docker-compose.yml
+++ b/devops/local/docker-compose.yml
@@ -1,0 +1,45 @@
+# Local development dependencies for tournaments-backend
+#
+# How to use this file:
+# 1) Start services:
+#    docker compose -f devops/local/docker-compose.yml up -d
+#
+# 2) Stop services:
+#    docker compose -f devops/local/docker-compose.yml down
+#
+# 3) View logs:
+#    docker compose -f devops/local/docker-compose.yml logs -f
+#
+# Services included:
+# - postgres: application database on localhost:5432
+# - maildev : local SMTP server on localhost:1025 and UI on localhost:1080
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: tournaments-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: tournaments
+      POSTGRES_USER: heri
+      POSTGRES_PASSWORD: 0Nepunch1
+    ports:
+      - "5432:5432"
+    volumes:
+      - tournaments-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U heri -d tournaments"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  maildev:
+    image: maildev/maildev:2.2.1
+    container_name: tournaments-maildev
+    restart: unless-stopped
+    ports:
+      - "1025:1025"
+      - "1080:1080"
+
+volumes:
+  tournaments-postgres-data:

--- a/devops/local/docker-compose.yml
+++ b/devops/local/docker-compose.yml
@@ -20,9 +20,9 @@ services:
     container_name: tournaments-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: tournaments
-      POSTGRES_USER: heri
-      POSTGRES_PASSWORD: 0Nepunch1
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - "5432:5432"
     volumes:
@@ -47,9 +47,9 @@ services:
       - "8080:8080"
     environment:
       # This overrides the localhost setting in your application.properties
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/tournaments
-      - SPRING_DATASOURCE_USERNAME=heri
-      - SPRING_DATASOURCE_PASSWORD=0Nepunch1
+      - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}
+      - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
     depends_on:
       postgres:
         condition: service_healthy  # Wait until Postgres is actually ready

--- a/devops/local/docker-compose.yml
+++ b/devops/local/docker-compose.yml
@@ -41,5 +41,18 @@ services:
       - "1025:1025"
       - "1080:1080"
 
+  backend: 
+    build: ../../.
+    ports:
+      - "8080:8080"
+    environment:
+      # This overrides the localhost setting in your application.properties
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/tournaments
+      - SPRING_DATASOURCE_USERNAME=heri
+      - SPRING_DATASOURCE_PASSWORD=0Nepunch1
+    depends_on:
+      postgres:
+        condition: service_healthy  # Wait until Postgres is actually ready
+
 volumes:
   tournaments-postgres-data:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 app.base-url=http://localhost:8080
 spring.application.name=tournaments-backend-practice
-spring.datasource.url=jdbc:postgresql://localhost:5432/tournaments
-spring.datasource.username=heri
-spring.datasource.password=0Nepunch1
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/tournaments}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:heri}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:0Nepunch1}
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true

--- a/start-app.sh
+++ b/start-app.sh
@@ -1,10 +1,27 @@
 #!/bin/bash
-# starts mail server in the background
-maildev &
-# if database is not running
-if ! systemctl is-active --quiet postgresql; then
-    # start database
-    sudo systemctl start postgresql
+
+set -e
+
+COMPOSE_FILE="devops/local/docker-compose.yml"
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    echo "[start-app] Starting PostgreSQL + MailDev with Docker Compose..."
+    docker compose -f "$COMPOSE_FILE" up -d
+else
+    echo "[start-app] Docker Compose not available. Falling back to local services..."
+
+    # Start maildev locally if available
+    if command -v maildev >/dev/null 2>&1; then
+        maildev &
+    else
+        echo "[start-app] maildev not found in PATH. Install it or use Docker Compose."
+    fi
+
+    # Start PostgreSQL service locally if not running
+    if command -v systemctl >/dev/null 2>&1 && ! systemctl is-active --quiet postgresql; then
+        sudo systemctl start postgresql
+    fi
 fi
-# starts tournaments backend app in the background
+
+echo "[start-app] Starting tournaments backend app..."
 java -jar target/tournaments-backend-0.0.1-SNAPSHOT.jar &

--- a/start-app.sh
+++ b/start-app.sh
@@ -21,7 +21,7 @@ else
     if command -v systemctl >/dev/null 2>&1 && ! systemctl is-active --quiet postgresql; then
         sudo systemctl start postgresql
     fi
-fi
 
-echo "[start-app] Starting tournaments backend app..."
-java -jar target/tournaments-backend-0.0.1-SNAPSHOT.jar &
+    echo "[start-app] Starting tournaments backend app..."
+    java -jar target/tournaments-backend-0.0.1-SNAPSHOT.jar &
+fi

--- a/stop-app.sh
+++ b/stop-app.sh
@@ -1,9 +1,27 @@
 #!/bin/bash
-# stop the spring app
-ID=$(sudo lsof -i:8080 | sed -n '2p' | awk '{print $2}')
-sudo kill -9 $ID
-# stop the database
-sudo systemctl stop postgresql
-# stop the mail server
-ID=$(sudo lsof -i:1080 | sed -n '2p' | awk '{print $2}')
-sudo kill -9 $ID
+
+set -e
+
+COMPOSE_FILE="devops/local/docker-compose.yml"
+
+# Stop Spring app (if listening on 8080)
+APP_ID=$(lsof -ti:8080 || true)
+if [ -n "$APP_ID" ]; then
+	kill -9 $APP_ID || true
+fi
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+	echo "[stop-app] Stopping Docker Compose services..."
+	docker compose -f "$COMPOSE_FILE" down
+else
+	# Stop local PostgreSQL service if available
+	if command -v systemctl >/dev/null 2>&1; then
+		sudo systemctl stop postgresql || true
+	fi
+
+	# Stop local MailDev (if listening on 1080)
+	MAILDEV_ID=$(lsof -ti:1080 || true)
+	if [ -n "$MAILDEV_ID" ]; then
+		kill -9 $MAILDEV_ID || true
+	fi
+fi

--- a/stop-app.sh
+++ b/stop-app.sh
@@ -4,16 +4,16 @@ set -e
 
 COMPOSE_FILE="devops/local/docker-compose.yml"
 
-# Stop Spring app (if listening on 8080)
-APP_ID=$(lsof -ti:8080 || true)
-if [ -n "$APP_ID" ]; then
-	kill -9 $APP_ID || true
-fi
-
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
 	echo "[stop-app] Stopping Docker Compose services..."
 	docker compose -f "$COMPOSE_FILE" down
 else
+	# Stop Spring app (if listening on 8080)
+	APP_ID=$(lsof -ti:8080 || true)
+	if [ -n "$APP_ID" ]; then
+		kill -9 $APP_ID || true
+	fi
+
 	# Stop local PostgreSQL service if available
 	if command -v systemctl >/dev/null 2>&1; then
 		sudo systemctl stop postgresql || true


### PR DESCRIPTION
## Summary
This PR introduces an organized local development dependency setup for the backend using Docker Compose, and aligns scripts/docs around it.

## Related issue
Closes #102

## What changed
- Added local infrastructure folder: `devops/local/`
- Added compose stack: `devops/local/docker-compose.yml`
  - PostgreSQL (`postgres:16-alpine`) on `5432`
  - MailDev (`maildev/maildev:2.2.1`) on `1025` (SMTP) and `1080` (UI)
  - Postgres healthcheck + persistent volume
- Added local infra documentation: `devops/local/README.md`
  - Docker requirement
  - Docker install instructions (Ubuntu/Debian, macOS, Windows)
  - Start/stop/logs usage
- Updated scripts:
  - `start-app.sh` now starts compose dependencies from `devops/local/docker-compose.yml` (fallback to local services if Docker is unavailable)
  - `stop-app.sh` now stops compose dependencies using the same file (fallback to local services)
- Updated root `README.md` to point local dependency instructions to `devops/local/README.md`.
- Removed root-level `docker-compose.yml` in favor of organized location under `devops/local/`.

## Validation
- Compose file parses successfully:
  - `docker compose -f devops/local/docker-compose.yml config`
- Runtime test result:
  - `maildev` starts successfully
  - `postgres` start may fail if host port `5432` is already occupied (expected behavior due to port conflict)

## Notes
If `5432` is in use, free the port or remap the Postgres host port in compose for local environments.